### PR TITLE
修复搜索时会触发两次请求问题

### DIFF
--- a/src/pages/movie/search/index.js
+++ b/src/pages/movie/search/index.js
@@ -192,7 +192,7 @@ function DownloadRecords(props) {
     console.log('param-->', param);
 
     const searchData = (keyword) => {
-        if (keyword) {
+        if (keyword && !loading) {
             setLoading(true);
             setRecords();
             setParam({keyword})
@@ -233,7 +233,7 @@ function DownloadRecords(props) {
 
     useEffect(() => {
         searchData(param.keyword)
-    }, [param])
+    }, [])
 
     const search = useCallback((keyword) => {
         searchData(keyword)


### PR DESCRIPTION
URL参数仅仅是第一次加载搜索页启用，无需监控多次调用